### PR TITLE
Fix npm package contents, bump to v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.5.3
+
+- fix npm-package contents to actually include compiled output. (oops!)
+
 # 0.5.2
 
 - explicitly support BuckleScript, and publish to npm as bs-gen

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-gen",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "sources": [
     {
       "dir": "src",

--- a/gen.opam
+++ b/gen.opam
@@ -3,7 +3,7 @@ maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "Iterators for OCaml, both restartable and consumable"
 author: [ "Simon Cruanes" "ELLIOTTCABLE" ]
 name: "gen"
-version: "0.5.2"
+version: "0.5.3"
 build: [
   ["dune" "build" "@install" "-p" name]
   ["dune" "runtest" "-p" name] {with-test}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-gen",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "bs-platform": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-4.0.3.tgz",
-      "integrity": "sha1-RRDByRXMWxabVxflwK2lLT+Z/5g=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-5.2.1.tgz",
+      "integrity": "sha512-3ISP+RBC/NYILiJnphCY0W3RTYpQ11JGa2dBBLVug5fpFZ0qtSaL3ZplD8MyjNeXX2bC7xgrWfgBSn8Tc9om7Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "url": "git+https://github.com/c-cube/gen.git"
   },
   "contributors": [
-     "Simon Cruanes <simon.cruanes.2007@m4x.org>",
-     "ELLIOTTCABLE <git@ell.io>"
+    "Simon Cruanes <simon.cruanes.2007@m4x.org>",
+    "ELLIOTTCABLE <git@ell.io>"
   ],
   "license": "BSD-2-Clause",
   "bugs": {
@@ -40,9 +40,9 @@
   },
   "homepage": "http://c-cube.github.io/gen/",
   "devDependencies": {
-    "bs-platform": "^4.0.3"
+    "bs-platform": "^5.2.1"
   },
   "peerDependencies": {
-    "bs-platform": ">=4.0.0"
+    "bs-platform": ">=5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
     "clean": "bsb -clean-world",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "files": [
+    "bsconfig.json",
+    "src",
+    "!**/dune",
+    "!**/dune-project",
+    "!**/.merlin"
+  ],
   "keywords": [
     "BuckleScript",
     "ReasonML",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-gen",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Simple, efficient iterators for OCaml",
   "main": "src/gen.bs.js",
   "scripts": {


### PR DESCRIPTION
Turns out that I screwed up the build in the release-version.

Fixing this will require a version-bump; I've gone ahead and tagged the bumping-commit, so make sure to pull tags. (Not sure how GitHub's merging handles all that; I avoid it like the plague.)

I'll hold off on pushing to npm until I'm sure you want to merge this!