### PR TITLE
Drop dune-configurator, bytes dependencies

### DIFF
--- a/gen.opam
+++ b/gen.opam
@@ -12,8 +12,6 @@ build: [
 ]
 depends: [
   "dune" {>= "1.1"}
-  "dune-configurator"
-  "base-bytes"
   "seq"
   "odoc" {with-doc}
   "qcheck" {with-test}

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,6 @@
 (executable
  (name mkshims)
- (modules mkshims)
- (libraries dune.configurator))
+ (modules mkshims))
 
 (rule
  (targets GenShims_.ml)
@@ -21,5 +20,4 @@
   (modules Gen GenLabels GenM GenClone GenMList GenM_intf Gen_intf GenLabels_intf GenShims_)
   (flags :standard -warn-error -a+8 -safe-string -nolabels)
   (ocamlopt_flags :standard (:include flambda.flags))
-  (libraries bytes seq))
-
+  (libraries seq))

--- a/src/mkshims.ml
+++ b/src/mkshims.ml
@@ -1,5 +1,3 @@
-module C = Configurator.V1
-
 let write_file f s =
   let out = open_out f in
   output_string out s; flush out; close_out out
@@ -9,8 +7,5 @@ let shims_pre_407 = "module Stdlib = Pervasives"
 let shims_post_407 = "module Stdlib = Stdlib"
 
 let () =
-  C.main ~name:"mkshims" (fun c ->
-    let version = C.ocaml_config_var_exn c "version" in
-    let major, minor = Scanf.sscanf version "%u.%u" (fun maj min -> maj, min) in
-    write_file "GenShims_.ml" (if (major, minor) >= (4,7) then shims_post_407 else shims_pre_407);
-    )
+  let major, minor = Scanf.sscanf Sys.ocaml_version "%u.%u" (fun maj min -> maj, min) in
+  write_file "GenShims_.ml" (if (major, minor) >= (4,7) then shims_post_407 else shims_pre_407);


### PR DESCRIPTION
This PR proposes two simplifications to the build of this library:

1) Currently this package depends on `dune-configurator` to read the OCaml version. It can use `Sys.ocaml_version` instead.

2) Drop the explicit dependency on the `bytes` package; `bytes` was introduced in 4.02 and this package requires at least 4.03.

Removing these dependencies makes the package easier to build in a monorepo setting.